### PR TITLE
Add handling GHC 7.10.1

### DIFF
--- a/src/TweetParsers.hs
+++ b/src/TweetParsers.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module TweetParsers where
 
 import              Data.Aeson.Types
@@ -8,11 +6,7 @@ import              Control.Applicative
 import              Data.Time.LocalTime (LocalTime)
 import              Control.Monad
 import              Data.Text
-#if MIN_VERSION_time(1,5,0)
-import Data.Time.Format(defaultTimeLocale)
-#else
 import              System.Locale (defaultTimeLocale)
-#endif
 import              Debug.Trace
 
 data TweetUrl = TweetUrl { expandedUrl :: String

--- a/src/TweetParsers.hs
+++ b/src/TweetParsers.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module TweetParsers where
 
 import              Data.Aeson.Types
@@ -6,7 +8,11 @@ import              Control.Applicative
 import              Data.Time.LocalTime (LocalTime)
 import              Control.Monad
 import              Data.Text
+#if MIN_VERSION_time(1,5,0)
+import Data.Time.Format(defaultTimeLocale)
+#else
 import              System.Locale (defaultTimeLocale)
+#endif
 import              Debug.Trace
 
 data TweetUrl = TweetUrl { expandedUrl :: String

--- a/src/TweetParsers.hs
+++ b/src/TweetParsers.hs
@@ -6,7 +6,7 @@ import              Control.Applicative
 import              Data.Time.LocalTime (LocalTime)
 import              Control.Monad
 import              Data.Text
-import              System.Locale (defaultTimeLocale)
+import              Data.Time.Locale.Compat (defaultTimeLocale)
 import              Debug.Trace
 
 data TweetUrl = TweetUrl { expandedUrl :: String

--- a/twitterbot.cabal
+++ b/twitterbot.cabal
@@ -20,10 +20,24 @@ executable twitterbot
   default-extensions:          OverloadedStrings
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.8, http-conduit >= 2.1.5, network >= 2.6, bytestring >= 0.10,
-                       http-types >= 0.8.6, authenticate-oauth >= 1.5.1, data-default >= 0.5.3,
-                       json >= 0.7, template-haskell, transformers, aeson >= 0.6.1,
-                       old-locale >= 1.0.0.6, time >= 1.4.2, unordered-containers >= 0.2.5.1,
-                       text >= 1.2.0.4, containers >= 0.5.5.1, conduit >= 1.2.4
+  build-depends:
+    base                 >= 4.7 && < 4.9,
+    http-conduit         >= 2.1.5,
+    network              >= 2.6,
+    bytestring           >= 0.10,
+    http-types           >= 0.8.6,
+    authenticate-oauth   >= 1.5.1,
+    data-default         >= 0.5.3,
+    json                 >= 0.7,
+    template-haskell,
+    transformers,
+    aeson                >= 0.6.1,
+    old-locale           >= 1.0.0.6,
+    time                 >= 1.4.2,
+    unordered-containers >= 0.2.5.1,
+    text                 >= 1.2.0.4,
+    containers           >= 0.5.5.1,
+    conduit              >= 1.2.4
+
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/twitterbot.cabal
+++ b/twitterbot.cabal
@@ -32,7 +32,7 @@ executable twitterbot
     template-haskell,
     transformers,
     aeson                >= 0.6.1,
-    old-locale           >= 1.0.0.6,
+    time-locale-compat   >= 0.1.0.1,
     time                 >= 1.4.2,
     unordered-containers >= 0.2.5.1,
     text                 >= 1.2.0.4,

--- a/twitterbot.cabal
+++ b/twitterbot.cabal
@@ -15,15 +15,38 @@ build-type:          Simple
 -- extra-source-files:  
 cabal-version:       >=1.10
 
+flag old-locale
+  description: If false then depend on time >= 1.5
+               .
+               If true then depend on time < 1.5 together with old-locale
+  default: False
+
 executable twitterbot
   main-is:             Main.hs
   default-extensions:          OverloadedStrings
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.8, http-conduit >= 2.1.5, network >= 2.6, bytestring >= 0.10,
-                       http-types >= 0.8.6, authenticate-oauth >= 1.5.1, data-default >= 0.5.3,
-                       json >= 0.7, template-haskell, transformers, aeson >= 0.6.1,
-                       old-locale >= 1.0.0.6, time >= 1.4.2, unordered-containers >= 0.2.5.1,
-                       text >= 1.2.0.4, containers >= 0.5.5.1, conduit >= 1.2.4
+  build-depends:
+    base                 >= 4.7 && <4.9,
+    http-conduit         >= 2.1.5,
+    network              >= 2.6,
+    bytestring           >= 0.10,
+    http-types           >= 0.8.6,
+    authenticate-oauth   >= 1.5.1,
+    data-default         >= 0.5.3,
+    json                 >= 0.7,
+    template-haskell,
+    transformers,
+    aeson                >= 0.6.1,
+    unordered-containers >= 0.2.5.1,
+    text                 >= 1.2.0.4,
+    containers           >= 0.5.5.1,
+    conduit              >= 1.2.4
+
+  if flag(old-locale)
+    build-depends: time < 1.5, old-locale
+  else
+    build-depends: time >= 1.5
+
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/twitterbot.cabal
+++ b/twitterbot.cabal
@@ -15,38 +15,15 @@ build-type:          Simple
 -- extra-source-files:  
 cabal-version:       >=1.10
 
-flag old-locale
-  description: If false then depend on time >= 1.5
-               .
-               If true then depend on time < 1.5 together with old-locale
-  default: False
-
 executable twitterbot
   main-is:             Main.hs
   default-extensions:          OverloadedStrings
   -- other-modules:       
   -- other-extensions:    
-  build-depends:
-    base                 >= 4.7 && <4.9,
-    http-conduit         >= 2.1.5,
-    network              >= 2.6,
-    bytestring           >= 0.10,
-    http-types           >= 0.8.6,
-    authenticate-oauth   >= 1.5.1,
-    data-default         >= 0.5.3,
-    json                 >= 0.7,
-    template-haskell,
-    transformers,
-    aeson                >= 0.6.1,
-    unordered-containers >= 0.2.5.1,
-    text                 >= 1.2.0.4,
-    containers           >= 0.5.5.1,
-    conduit              >= 1.2.4
-
-  if flag(old-locale)
-    build-depends: time < 1.5, old-locale
-  else
-    build-depends: time >= 1.5
-
+  build-depends:       base >=4.7 && <4.8, http-conduit >= 2.1.5, network >= 2.6, bytestring >= 0.10,
+                       http-types >= 0.8.6, authenticate-oauth >= 1.5.1, data-default >= 0.5.3,
+                       json >= 0.7, template-haskell, transformers, aeson >= 0.6.1,
+                       old-locale >= 1.0.0.6, time >= 1.4.2, unordered-containers >= 0.2.5.1,
+                       text >= 1.2.0.4, containers >= 0.5.5.1, conduit >= 1.2.4
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
GHC 7.10.1 introduces breaks backwards compatibility with time 1.4

Here is a simple fix taken from [aeson](https://github.com/bos/aeson/commit/730a8c42b75f38e241da39933b03735a7c905538)

I am not sure if it builds on GHC 7.8

Probably setting up Travis would be a good idea.
